### PR TITLE
Fix git versions installed on Mac

### DIFF
--- a/tidy/core.py
+++ b/tidy/core.py
@@ -170,9 +170,10 @@ def _load_commit_schema(path=None, full=True):
 
 def _check_git_version():
     """Verify git version"""
-    git_version = utils.shell_stdout(
-        "git --version | rev | cut -f 1 -d' ' | rev"
-    )
+    git_version_out = utils.shell_stdout("git --version").split(' ')
+    assert len(git_version_out) >= 2
+    git_version = git_version_out[2]
+
     if version.parse(git_version) < version.parse('2.22.0'):
         raise RuntimeError(
             f'Must have git version >= 2.22.0 (version = {git_version})'

--- a/tidy/tests/test_core.py
+++ b/tidy/tests/test_core.py
@@ -99,10 +99,11 @@ def test_load_commit_schema(
 @pytest.mark.parametrize(
     'git_version, expected_exception',
     [
-        ('2.22.0', does_not_raise()),
-        ('2.22.1', does_not_raise()),
-        ('2.23', does_not_raise()),
-        ('1.1', pytest.raises(RuntimeError)),
+        ('git version 2.22.0', does_not_raise()),
+        ('git version 2.22.1', does_not_raise()),
+        ('git version 2.23', does_not_raise()),
+        ('git version 2.30.1 (Apple Git-130)', does_not_raise()),
+        ('git version 1.1', pytest.raises(RuntimeError)),
     ],
 )
 def test_check_git_version(mocker, git_version, expected_exception):


### PR DESCRIPTION
The return of ``git --version`` on Macs produce a different version string that
was previously not supported in git-tidy. This is now fixed.

Type: bug

@tomage FYI I ran into the bug for using git tidy on new Macs. This fixes it and tests it