### PR TITLE
Fix errors parsing hyphenated trailers

### DIFF
--- a/tidy/core.py
+++ b/tidy/core.py
@@ -483,7 +483,8 @@ def _git_log_as_yaml(git_log_cmd):
     # author_name: The author name (%an)
     # author_email: The author email (%ae)
     delimiter = "\n<-------->"
-    git_log_stdout = utils.shell_stdout(
+
+    git_log_cmd = (
         f"{git_log_cmd} "
         '--format="'
         "sha: %H%n"
@@ -498,6 +499,7 @@ def _git_log_as_yaml(git_log_cmd):
         "trailers: [*{*%(trailers:separator=*%x7d*%x2c*%x7b*)*}*]"
         f'%n{delimiter}"'
     )
+    git_log_stdout = utils.shell_stdout(git_log_cmd)
 
     # Escape any double quotes used in trailers
     git_log_stdout = re.sub(
@@ -511,7 +513,7 @@ def _git_log_as_yaml(git_log_cmd):
     git_log_stdout = re.sub(r"\*{\*\*}\*", r"{}", git_log_stdout)
 
     # Quote all trailer values
-    git_log_stdout = re.sub(r"\*{\*(\w+: )", r'{\1"', git_log_stdout)
+    git_log_stdout = re.sub(r"\*{\*([\w\-]+: )", r'{\1"', git_log_stdout)
     git_log_stdout = re.sub(r"\*}\*", r'"}', git_log_stdout)
 
     return [msg for msg in git_log_stdout.split(delimiter) if msg]
@@ -635,7 +637,7 @@ def commit(no_verify=False, allow_empty=False, defaults=None):
 
     for key, value in entry.items():
         if key not in ["summary", "description"]:
-            key = key.replace("_", " ").title().replace("_", "-").strip()
+            key = key.capitalize().replace("_", "-").strip()
             commit_msg += f"{key}: {value.strip()}\n"
 
     commit_msg = commit_msg.strip()

--- a/tidy/tests/test_integration.py
+++ b/tidy/tests/test_integration.py
@@ -55,6 +55,11 @@ def tidy_config(tmp_path, mocker):
         "  type: string\n"
         "  required: false\n"
         '  condition: ["!=", "type", "trivial"]\n'
+        "\n"
+        "- label: multi_word\n"
+        "  type: string\n"
+        "  required: false\n"
+        '  condition: ["!=", "type", "trivial"]\n'
     )
 
     tidy_commit_template = tidy_root / "log.tpl"
@@ -99,6 +104,7 @@ def git_tidy_repo(tidy_config):
     os.chdir(tidy_config)
 
     utils.shell("git init .")
+    utils.shell("git branch -m master", check=False)
     utils.shell('git config user.email "you@example.com"')
     utils.shell('git config user.name "Your Name"')
     utils.shell(
@@ -258,6 +264,7 @@ def test_commit_properties_and_range_filtering(mocker):
             "description": "description",
             "jira": "",
             "component": "",
+            "multi_word": "",
         },
         # Tests where a key in the middle of the final message is empty
         {
@@ -266,6 +273,7 @@ def test_commit_properties_and_range_filtering(mocker):
             "description": "description",
             "jira": "",
             "component": "django",
+            "multi_word": "hello",
         },
         # Tests committing key with double quotes
         {
@@ -274,6 +282,7 @@ def test_commit_properties_and_range_filtering(mocker):
             "description": '"description"',
             "jira": "",
             "component": '"""',
+            "multi_word": "",
         },
         # Tests no trailers
         {"summary": "summary"},


### PR DESCRIPTION
Trailers such as Co-authored-by were not correctly parsed by git-tidy. Users can now correctly supply hyphenated trailers manually, and they can also specify attributes with underscores in the commit message schema.

Type: bug